### PR TITLE
Test harness and optimization

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,24 +1,3 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for third-
-# party users, it should be done in your mix.exs file.
-
-# Sample configuration:
-#
-#     config :logger, :console,
-#       level: :info,
-#       format: "$date $time [$level] $metadata$message\n",
-#       metadata: [:user_id]
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,12 @@
+use Mix.Config
+
+config :tributary, ecto_repos: [Tributary.Repo]
+
+config :tributary, Tributary.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  database: "tributary_test",
+  username: System.get_env("TRIBUTARY_DB_USER") || System.get_env("USER")
+
+config :logger, :console,
+  level: :error

--- a/lib/tributary.ex
+++ b/lib/tributary.ex
@@ -16,16 +16,10 @@ defmodule Tributary do
               |> Ecto.Query.limit(^chunk_size) 
               |> __ENV__.module.all
 
-            cond do
-              Enum.count(results) > 0 ->
-                last_key = results
-                  |> Enum.reverse
-                  |> Enum.at(0)
-                  |> Map.get(key_name)
-                
+            case List.last(results) do
+              %{^key_name => last_key} ->
                 {results, {query, last_key}}
-
-              :otherwise ->
+              nil ->
                 {:halt, {query, last_seen_key}}
             end
           end,

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Tributary.Mixfile do
 
   def project do
     [app: :tributary,
-     elixir: "~> 1.0",
+     elixir: "~> 1.2",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Tributary.Mixfile do
   def project do
     [app: :tributary,
      elixir: "~> 1.0",
+     elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps,
@@ -17,7 +18,7 @@ defmodule Tributary.Mixfile do
      source_url: @source_url,
      homepage_url: @source_url,
      description: """
-     A simple stream generation library for Ecto queries that facilitates 
+     A simple stream generation library for Ecto queries that facilitates
      more efficient paging of queries both in the database and in your
      Ecto-reliant applicaton.
      """
@@ -25,15 +26,22 @@ defmodule Tributary.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :ecto]]
+    [applications: applications(Mix.env)]
   end
 
+  defp applications(:test), do: [:postgrex, :ecto, :logger]
+  defp applications(_), do: [:ecto, :logger]
+
   defp deps do
-    [{:ecto, "~> 1.1"},
+    [{:ecto, "~> 2.0"},
      {:earmark, "~> 0.1", only: [:dev, :docs]},
      {:ex_doc, "~> 0.10", only: [:dev, :docs]},
+     {:postgrex, "~> 0.11.2", optional: true}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   defp package do
     [maintainers: ["David Antaramian"],

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,8 @@
-%{"decimal": {:hex, :decimal, "1.1.1"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ecto": {:hex, :ecto, "1.1.5"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "poolboy": {:hex, :poolboy, "1.5.1"}}
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "db_connection": {:hex, :db_connection, "1.0.0-rc.4", "fad1f772c151cc6bde82412b8d72319968bc7221df8ef7d5e9d7fde7cb5c86b7", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
+  "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ecto": {:hex, :ecto, "2.0.3", "3d416156e0b7578a31b6925ee07de76b53684ffb4f106b863e35b423b1004b08", [:mix], [{:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
+  "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]}}

--- a/priv/repo/migrations/1_create_widgets.exs
+++ b/priv/repo/migrations/1_create_widgets.exs
@@ -1,0 +1,11 @@
+defmodule TributaryTest.Repo.Migrations.CreateWidgets do
+  use Ecto.Migration
+
+  def change do
+    create table(:widgets) do
+      add :name, :string
+
+      timestamps
+    end
+  end
+end

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -1,0 +1,5 @@
+defmodule Tributary.Repo do
+  use Ecto.Repo, otp_app: :tributary
+
+  use Tributary
+end

--- a/test/support/widget.ex
+++ b/test/support/widget.ex
@@ -1,0 +1,12 @@
+defmodule Tributary.Widget do
+  use Ecto.Schema
+
+  import Ecto.Query
+
+  schema "widgets" do
+    field :name, :string
+
+    timestamps
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Tributary.Repo.start_link()
 ExUnit.start()

--- a/test/tributary_test.exs
+++ b/test/tributary_test.exs
@@ -1,7 +1,44 @@
 defmodule TributaryTest do
   use ExUnit.Case
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  import Ecto.Query
+
+  alias Tributary.{Repo, Widget}
+
+  defp create_widgets!(n, attributes \\ %{}) do
+    1..n
+    |> Enum.map(fn i ->
+      %Widget{name: "Widget #{i}"} |> Repo.insert!
+    end)
   end
+
+  setup do
+    Ecto.Adapters.SQL.Sandbox.mode(Tributary.Repo, :manual)
+
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Tributary.Repo)
+  end
+
+
+  test "stream single chunk" do
+    create_widgets!(10)
+
+    stream = Repo.stream(Widget)
+    assert Enum.count(stream) == 10
+
+    names = Enum.map(stream, fn %{name: name} -> name end)
+    assert ["Widget 1", "Widget 2", "Widget 3" | _] = names
+    assert List.last(names) == "Widget 10"
+  end
+
+  test "stream multiple chunks" do
+    create_widgets!(100)
+
+    stream = Repo.stream(Widget, chunk_size: 20)
+    assert Enum.count(stream) == 100
+
+    names = Enum.map(stream, fn %{name: name} -> name end)
+    assert ["Widget 1", "Widget 2", "Widget 3" | _] = names
+    assert List.last(names) == "Widget 100"
+  end
+
 end


### PR DESCRIPTION

This patch: 
- adds a very minimal test harness
- simplifies and optimises the last key lookup by going over the chunk only once.

It's tested against Ecto 2.0 (dependencies were updated) and now requires Elixir 1.2+ because it uses the map key pattern matching introduced back then.