### PR TITLE
Support Query Options with Stream

### DIFF
--- a/lib/tributary.ex
+++ b/lib/tributary.ex
@@ -5,16 +5,18 @@ defmodule Tributary do
       import Ecto.Query.API, only: [field: 2]
 
       def stream(query, opts \\ []) do
-        initial_key = Keyword.get(opts, :initial_key, 0)
-        key_name = Keyword.get(opts, :key_name, :id)
-        chunk_size = Keyword.get(opts, :chunk_size, 500)
+        {trib_opts, repo_opts} = Keyword.split(opts, [:initial_key, :key_name, :chunk_size])
+
+        initial_key = Keyword.get(trib_opts, :initial_key, 0)
+        key_name = Keyword.get(trib_opts, :key_name, :id)
+        chunk_size = Keyword.get(trib_opts, :chunk_size, 500)
 
         Stream.resource(fn -> {query, initial_key} end,
           fn {query, last_seen_key} ->
             results = query
               |> Ecto.Query.where([r], field(r, ^key_name) > ^last_seen_key)
               |> Ecto.Query.limit(^chunk_size) 
-              |> __ENV__.module.all
+              |> __ENV__.module.all(repo_opts)
 
             case List.last(results) do
               %{^key_name => last_key} ->

--- a/test/lib/tributary_test.exs
+++ b/test/lib/tributary_test.exs
@@ -31,4 +31,15 @@ defmodule TributaryTest do
     assert ["Widget 1", "Widget 2", "Widget 3" | _] = names
     assert List.last(names) == "Widget 100"
   end
+
+  test "stream with database options" do
+    create_widgets!(100)
+
+    stream = Repo.stream(Widget, chunk_size: 20, timeout: 20_000)
+    assert Enum.count(stream) == 100
+
+    names = Enum.map(stream, fn %{name: name} -> name end)
+    assert ["Widget 1", "Widget 2", "Widget 3" | _] = names
+    assert List.last(names) == "Widget 100"
+  end
 end


### PR DESCRIPTION
There are several options which could not be passed in that are
handy to have for debugging as well as tuning.  That list is
currently:

 * timeout
 * pool_timeout
 * log

This documentation can be found here:
https://hexdocs.pm/ecto/Ecto.Repo.html#module-shared-options

This allows users of the library to pass in these as options to
the stream as well as the other supported options the stream itself
supports.